### PR TITLE
refactor: centralize gltf loading

### DIFF
--- a/src/blocks.js
+++ b/src/blocks.js
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+import { loadGltf } from './utils/load-gltf.js';
 
 const FORWARD_DIST = 0.8;
 const HEIGHT_OFFSET = 0.40;
@@ -31,7 +32,7 @@ export class BlocksManager {
 
   async ensureLoaded() {
     if (this.template) return;
-    const gltf = await this._load('./assets/wuerfel.glb');
+    const gltf = await loadGltf(this.loader, './assets/wuerfel.glb');
     const root = gltf.scene || gltf.scenes?.[0];
     if (!root) throw new Error('wuerfel.glb ohne Szene');
 
@@ -193,11 +194,5 @@ export class BlocksManager {
       }
     }
     return bursts;
-  }
-
-  _load(url) {
-    return new Promise((resolve, reject) => {
-      this.loader.load(url, resolve, undefined, reject);
-    });
   }
 }

--- a/src/coins.js
+++ b/src/coins.js
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+import { loadGltf } from './utils/load-gltf.js';
 
 const COIN_DIAMETER = 0.14;
 const GRAVITY = -3.8;
@@ -30,7 +31,7 @@ export class CoinManager {
   }
 
   async _loadTemplate() {
-    const gltf = await this._load('./assets/coin.glb');
+    const gltf = await loadGltf(this.loader, './assets/coin.glb');
     const root = gltf.scene || gltf.scenes?.[0];
     if (!root) throw new Error('coin.glb ohne Szene');
 
@@ -170,11 +171,5 @@ export class CoinManager {
         this._return(inst);
       }
     }
-  }
-
-  _load(url) {
-    return new Promise((resolve, reject) => {
-      this.loader.load(url, resolve, undefined, reject);
-    });
   }
 }

--- a/src/fails.js
+++ b/src/fails.js
@@ -1,6 +1,7 @@
 // ./fails.js
 import * as THREE from 'three';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+import { loadGltf } from './utils/load-gltf.js';
 
 export class FailManager {
   constructor(scene) {
@@ -14,10 +15,11 @@ export class FailManager {
 
   async preload() {
     if (this._preloadPromise) return this._preloadPromise;
-    this._preloadPromise = new Promise((resolve) => {
-      this.loader.load('./assets/fail.glb', (gltf) => {
+    this._preloadPromise = (async () => {
+      try {
+        const gltf = await loadGltf(this.loader, './assets/fail.glb');
         const root = gltf.scene || gltf.scenes?.[0];
-        if (!root) { resolve(); return; }
+        if (!root) return;
         root.traverse(o => {
           if (o.isMesh && o.material) {
             if ('emissive' in o.material) o.material.emissive.set(0x990000);
@@ -27,9 +29,8 @@ export class FailManager {
         });
         this.template = root;
         for (let i=0;i<6;i++) this._return(this._makeInstance());
-        resolve();
-      }, undefined, () => resolve());
-    });
+      } catch {}
+    })();
     return this._preloadPromise;
   }
 

--- a/src/groove-character.js
+++ b/src/groove-character.js
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+import { loadGltf } from './utils/load-gltf.js';
 
 const ANIMATION_DURATION = 2000; // 2 Sekunden in Milliseconds
 const CROSSFADE_DURATION = 0.5; // 0.5 Sekunden für weiche Übergänge
@@ -64,7 +65,7 @@ export class GrooveCharacterManager {
 
   async _loadModel(name, url) {
     try {
-      const gltf = await this._load(url);
+      const gltf = await loadGltf(this.loader, url);
       const root = gltf.scene || gltf.scenes?.[0];
       if (!root) throw new Error(`${url} ohne Szene`);
 
@@ -333,11 +334,5 @@ export class GrooveCharacterManager {
     this.isAnimating = false;
     this.isTransitioning = false;
     this.nextState = null;
-  }
-
-  _load(url) {
-    return new Promise((resolve, reject) => {
-      this.loader.load(url, resolve, undefined, reject);
-    });
   }
 }

--- a/src/utils/load-gltf.js
+++ b/src/utils/load-gltf.js
@@ -1,0 +1,5 @@
+export function loadGltf(loader, url) {
+  return new Promise((resolve, reject) => {
+    loader.load(url, resolve, undefined, reject);
+  });
+}


### PR DESCRIPTION
## Summary
- add shared loadGltf utility
- refactor model managers to use loadGltf instead of per-file loaders

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a60c8a6520832e9f5cb85e337ce234