### PR TITLE
Use existing equation element and move styles to CSS

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -8,25 +8,6 @@ export class UI {
 
     // Equation-Banner (immer sichtbar im DOM Overlay)
     this.eqEl = document.getElementById('equation');
-    if (!this.eqEl) {
-      this.eqEl = document.createElement('div');
-      this.eqEl.id = 'equation';
-      this.eqEl.style.position = 'fixed';
-      this.eqEl.style.top = '16px';
-      this.eqEl.style.left = '50%';
-      this.eqEl.style.transform = 'translateX(-50%)';
-      this.eqEl.style.padding = '10px 14px';
-      this.eqEl.style.borderRadius = '12px';
-      this.eqEl.style.background = 'rgba(10,10,10,0.65)';
-      this.eqEl.style.backdropFilter = 'blur(6px)';
-      this.eqEl.style.border = '1px solid rgba(255,255,255,0.12)';
-      this.eqEl.style.color = '#fff';
-      this.eqEl.style.fontWeight = '800';
-      this.eqEl.style.fontSize = '1.1rem';
-      this.eqEl.style.zIndex = '10000';
-      this.eqEl.hidden = true;
-      document.body.appendChild(this.eqEl);
-    }
   }
 
   setHudVisible(v) {

--- a/styles.css
+++ b/styles.css
@@ -152,6 +152,6 @@ button:active { filter: brightness(0.95); }
   color: #fff;
   font-weight: 800;
   font-size: 1.1rem;
-  z-index: 1000;
+  z-index: 10000;
 }
 


### PR DESCRIPTION
## Summary
- Stop dynamically creating/styling the equation banner; use DOM element that already exists.
- Style the equation banner via the `.equation` CSS class and ensure it sits atop other UI.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a60e5f4754832ebde6a479adca4fa6