### PR TITLE
Compensate block scaling for number displays

### DIFF
--- a/src/math-game.js
+++ b/src/math-game.js
@@ -30,6 +30,9 @@ export class MathGame {
       if (!b.numberDisplay) {
         b.numberDisplay = this._createNumberDisplay(b);
         b.mesh.add(b.numberDisplay);
+        const inv = 1 / b.mesh.scale.x;      // Würfel ist uniform skaliert
+        b.numberDisplay.scale.setScalar(inv);
+        // Falls der Würfel später nicht uniform skaliert wird, separate Faktoren für x, y, z setzen.
       }
     });
 


### PR DESCRIPTION
## Summary
- Ensure block number displays stay consistent by inversely scaling with the parent cube
- Note future non-uniform scaling needs per-axis factors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6207f6658832ebc3cc4bd7c497aeb