### PR TITLE
Adjust number display orientation around Z axis

### DIFF
--- a/src/math-game.js
+++ b/src/math-game.js
@@ -223,11 +223,15 @@ export class MathGame {
       const mesh = new THREE.Mesh(geometry, material);
       mesh.renderOrder = 2000;
       mesh.frustumCulled = false;
-      const q = new THREE.Quaternion().setFromAxisAngle(
-        new THREE.Vector3(0, 1, 0), rotY
-      );
-      mesh.quaternion.copy(q);
+
+      // Rotate plane around Y and Z axes so text is oriented correctly
+      // If the texture appears mirrored, replace Math.PI / 2 with -Math.PI / 2
+      mesh.rotation.set(0, rotY, Math.PI / 2);
+
+      // Position the plane at the block face using the combined rotation
+      const q = new THREE.Quaternion().setFromEuler(mesh.rotation);
       mesh.position.set(0, 0, offset).applyQuaternion(q);
+
       group.add(mesh);
     };
 


### PR DESCRIPTION
## Summary
- Rotate plane meshes in math-game number displays around the Z axis to orient numbers upright.
- Add comment advising to flip sign if textures appear mirrored.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a770f0a664832e8dcfa85cef42afe6