### PR TITLE
Reposition stats board behind character

### DIFF
--- a/src/groove-character.js
+++ b/src/groove-character.js
@@ -215,7 +215,7 @@ export class GrooveCharacterManager {
     if (!this.statsBoard?.mesh) return;
     const behind = new THREE.Vector3(0, 0, -1)
       .applyQuaternion(this.characterQuaternion)
-      .multiplyScalar(-STATS_BOARD_DISTANCE);
+      .multiplyScalar(STATS_BOARD_DISTANCE);
     const pos = this.characterPosition.clone()
       .add(behind)
       .add(new THREE.Vector3(0, 1.5, 0));


### PR DESCRIPTION
## Summary
- Place stats board behind GrooveCharacter by applying positive distance along the model's backward axis

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a82b362ee0832eb8621778e25e5f79