### PR TITLE
Add volume control slider to HUD

### DIFF
--- a/src/audio-manager.js
+++ b/src/audio-manager.js
@@ -115,7 +115,12 @@ export class AudioManager {
   }
 
   setVolume(volume) {
-    this.volume = Math.max(0, Math.min(1, volume)); // 0-1 begrenzen
+    // Kann auch vor ensureLoaded aufgerufen werden
+    this.volume = Math.max(0, Math.min(1, volume));
+    // Falls der AudioContext bereits existiert, sicherstellen, dass er aktiv ist
+    if (this.audioContext && this.audioContext.state === 'suspended') {
+      this.audioContext.resume();
+    }
   }
 
   dispose() {

--- a/src/ui.js
+++ b/src/ui.js
@@ -8,6 +8,30 @@ export class UI {
 
     // Equation-Banner (immer sichtbar im DOM Overlay)
     this.eqEl = document.getElementById('equation');
+
+    // Lautstärke-Regler hinzufügen
+    this.audioManager = null;
+    this.volumeSlider = document.createElement('input');
+    Object.assign(this.volumeSlider, {
+      type: 'range',
+      min: '0',
+      max: '1',
+      step: '0.01',
+      value: '0.7'
+    });
+
+    const volRow = document.createElement('div');
+    volRow.className = 'row';
+    const volLabel = document.createElement('span');
+    volLabel.textContent = 'Volume';
+    volRow.appendChild(volLabel);
+    volRow.appendChild(this.volumeSlider);
+    if (this.hud) this.hud.appendChild(volRow);
+
+    this.volumeSlider.addEventListener('input', (e) => {
+      const v = parseFloat(e.target.value);
+      this.audioManager?.setVolume(v);
+    });
   }
 
   setHudVisible(v) {
@@ -37,5 +61,12 @@ export class UI {
     el.textContent = msg; el.style.opacity = '1';
     clearTimeout(this._toastTimer);
     this._toastTimer = setTimeout(() => el && (el.style.opacity = '0'), ms);
+  }
+
+  setAudioManager(am) {
+    this.audioManager = am;
+    if (this.volumeSlider) {
+      this.volumeSlider.value = am.volume.toString();
+    }
   }
 }

--- a/src/xr-session.js
+++ b/src/xr-session.js
@@ -75,6 +75,7 @@ export class XRApp {
     this.math   = new MathGame(this.ui, this.sceneRig.scene, this.fails);
     this.grooveCharacter = new GrooveCharacterManager(this.sceneRig.scene);
     this.audio  = new AudioManager();
+    this.ui.setAudioManager?.(this.audio);
     
     // Spieleinstellungen an MathGame weitergeben
     this.math.setGameSettings(this.gameOperation, this.gameMaxResult);


### PR DESCRIPTION
## Summary
- Add HUD volume slider and handler to adjust AudioManager volume
- Allow early volume changes and resume suspended audio context
- Link XR UI with AudioManager for volume control

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a850afad44832eb4ab4b58dd26737f