### PR TITLE
Add game mode and lives handling

### DIFF
--- a/src/math-game.js
+++ b/src/math-game.js
@@ -16,10 +16,11 @@ export class MathGame {
     this.current = { a: 1, b: 1, result: 2, operation: '+' };
     this.texCache = new Map();
     this.equationDisplay = new EquationDisplay(scene);
-    
+
     // Spieleinstellungen (Standard-Werte)
     this.operation = 'addition';
     this.maxResult = 20;
+    this.gameMode = 'endless';
   }
 
   attachBlocks(blocks, viewerPos = null, viewerQuat = null) {
@@ -54,6 +55,10 @@ export class MathGame {
       if (this.failManager && hitPosition) {
         this.failManager.spawn(hitPosition, new THREE.Vector3(0, 1, 0));
       }
+      // Im Endless-Modus sofort neue Aufgabe generieren
+      if (this.gameMode === 'endless') {
+        this._newProblem(false);
+      }
     }
     return isCorrect;
   }
@@ -65,6 +70,10 @@ export class MathGame {
   setGameSettings(operation, maxResult) {
     this.operation = operation;
     this.maxResult = maxResult;
+  }
+
+  setGameMode(mode) {
+    this.gameMode = mode;
   }
 
   dispose() {

--- a/src/xr-session.js
+++ b/src/xr-session.js
@@ -49,11 +49,19 @@ export class XRApp {
     // Spieleinstellungen
     this.gameOperation = 'addition';
     this.gameMaxResult = 20;
+    this.gameMode = 'endless';
+    this.remainingLives = 3;
   }
 
   setGameSettings(operation, maxResult) {
     this.gameOperation = operation;
     this.gameMaxResult = maxResult;
+  }
+
+  setGameMode(mode, lives = 3) {
+    this.gameMode = mode;
+    this.remainingLives = lives;
+    this.math?.setGameMode?.(mode);
   }
 
   async startAR() {
@@ -76,9 +84,10 @@ export class XRApp {
     this.grooveCharacter = new GrooveCharacterManager(this.sceneRig.scene);
     this.audio  = new AudioManager();
     this.ui.setAudioManager?.(this.audio);
-    
+
     // Spieleinstellungen an MathGame weitergeben
     this.math.setGameSettings(this.gameOperation, this.gameMaxResult);
+    this.math.setGameMode(this.gameMode);
     
     // AudioManager an GrooveCharacter weitergeben
     this.grooveCharacter.setAudioManager(this.audio);
@@ -175,6 +184,7 @@ export class XRApp {
     this._prevTime = null;
     this._didWarmup = false;
     this.wrongCount = 0;
+    this.remainingLives = 3;
   }
 
   async _warmupPipelinesOnce() {
@@ -266,6 +276,15 @@ export class XRApp {
           this.grooveCharacter?.statsBoard?.incrementWrong();
           // Bump-Sound abspielen
           this.audio?.playBumpSound();
+          if (this.gameMode === 'lives') {
+            this.remainingLives--;
+            this.ui.toast?.(`Lives: ${this.remainingLives}`);
+            if (this.remainingLives <= 0) {
+              this.ui.toast?.('Game Over!');
+              this.end();
+              return;
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
- allow configuring `gameMode` with remaining lives in XR session
- support game mode in MathGame and generate new tasks accordingly
- end session with game over message when lives run out

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a853a995c0832e94ab8188e747a7fd