### PR TITLE
Add lives counter to HUD and stats board

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,6 +56,7 @@
     <div id="hud" hidden>
       <div class="row">
         <span id="score">Score: 0</span>
+        <span id="lives">Lives: 3</span>
         <span id="fps">FPS: –</span>
       </div>
       <div class="row">

--- a/src/stats-board.js
+++ b/src/stats-board.js
@@ -5,6 +5,7 @@ export class StatsBoard {
   constructor() {
     this.correct = 0;
     this.wrong = 0;
+    this.lives = 3;
 
     // Canvas setup
     this.canvas = document.createElement('canvas');
@@ -41,9 +42,15 @@ export class StatsBoard {
     this.updateDisplay();
   }
 
+  setLives(value) {
+    this.lives = value;
+    this.updateDisplay();
+  }
+
   reset() {
     this.correct = 0;
     this.wrong = 0;
+    this.lives = 3;
     this.updateDisplay();
   }
 
@@ -64,7 +71,7 @@ export class StatsBoard {
     ctx.font = 'bold 48px system-ui, Arial, sans-serif';
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
-    const text = `Richtig: ${this.correct} | Falsch: ${this.wrong}`;
+    const text = `Richtig: ${this.correct} | Falsch: ${this.wrong} | Leben: ${this.lives}`;
 
     ctx.fillStyle = 'rgba(0, 0, 0, 0.5)';
     ctx.fillText(text, w / 2 + 2, h / 2 + 2);

--- a/src/ui.js
+++ b/src/ui.js
@@ -3,6 +3,7 @@ export class UI {
   constructor() {
     this.hud = document.getElementById('hud');
     this.scoreEl = document.getElementById('score');
+    this.livesEl = document.getElementById('lives');
     this.fpsEl = document.getElementById('fps');
     this._toastTimer = null;
 
@@ -40,6 +41,7 @@ export class UI {
   }
 
   setScore(v) { if (this.scoreEl) this.scoreEl.textContent = `Score: ${v}`; }
+  setLives(v) { if (this.livesEl) this.livesEl.textContent = `Lives: ${v}`; }
   setFps(fps) { if (this.fpsEl) this.fpsEl.textContent = `FPS: ${fps}`; }
 
   setEquation(text) {

--- a/src/xr-session.js
+++ b/src/xr-session.js
@@ -45,6 +45,7 @@ export class XRApp {
 
     // Statistik
     this.wrongCount = 0;
+    this.lives = 3;
 
     // Spieleinstellungen
     this.gameOperation = 'addition';
@@ -76,6 +77,11 @@ export class XRApp {
     this.grooveCharacter = new GrooveCharacterManager(this.sceneRig.scene);
     this.audio  = new AudioManager();
     this.ui.setAudioManager?.(this.audio);
+
+    // Lives zurücksetzen und anzeigen
+    this.lives = 3;
+    this.ui.setLives?.(this.lives);
+    this.grooveCharacter?.statsBoard?.setLives?.(this.lives);
     
     // Spieleinstellungen an MathGame weitergeben
     this.math.setGameSettings(this.gameOperation, this.gameMaxResult);
@@ -109,7 +115,11 @@ export class XRApp {
 
     // Session-Ende sauber behandeln
     session.addEventListener('end', () => {
-      try { this.ui.setHudVisible?.(false); } catch {}
+      try {
+        this.ui.setHudVisible?.(false);
+        this.ui.setLives?.(0);
+        this.grooveCharacter?.statsBoard?.setLives?.(0);
+      } catch {}
       this.cleanup();
       // Callback aufrufen, damit UI sich zurücksetzen kann
       if (this.onSessionEnd) this.onSessionEnd();
@@ -137,6 +147,8 @@ export class XRApp {
   }
 
   cleanup() {
+    this.ui.setLives?.(0);
+    this.grooveCharacter?.statsBoard?.setLives?.(0);
     // Animations-Loop stoppen
     try { this.renderer?.setAnimationLoop(null); } catch {}
 
@@ -175,6 +187,7 @@ export class XRApp {
     this._prevTime = null;
     this._didWarmup = false;
     this.wrongCount = 0;
+    this.lives = 3;
   }
 
   async _warmupPipelinesOnce() {
@@ -262,10 +275,14 @@ export class XRApp {
         } else {
           // Falsche Antwort → Zähler erhöhen, StatsBoard & Sound aktualisieren
           this.wrongCount++;
+          this.lives--;
+          this.ui.setLives?.(this.lives);
+          this.grooveCharacter?.statsBoard?.setLives?.(this.lives);
           this.grooveCharacter?.playIncorrectAnimation();
           this.grooveCharacter?.statsBoard?.incrementWrong();
           // Bump-Sound abspielen
           this.audio?.playBumpSound();
+          if (this.lives <= 0) this.end();
         }
       }
     }


### PR DESCRIPTION
## Summary
- Display remaining lives in HUD and 3D stats board
- Track lives in XR session and update on wrong answers or session end

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a853ac4764832e929a9a138cc43d6c