### PR TITLE
feat: add game over handling and stats reset

### DIFF
--- a/src/stats-board.js
+++ b/src/stats-board.js
@@ -2,9 +2,10 @@
 import * as THREE from 'three';
 
 export class StatsBoard {
-  constructor() {
+  constructor(initialLives = 3) {
     this.correct = 0;
     this.wrong = 0;
+    this.lives = initialLives;
 
     // Canvas setup
     this.canvas = document.createElement('canvas');
@@ -41,9 +42,15 @@ export class StatsBoard {
     this.updateDisplay();
   }
 
-  reset() {
+  decrementLives() {
+    this.lives = Math.max(0, this.lives - 1);
+    this.updateDisplay();
+  }
+
+  reset(lives = 3) {
     this.correct = 0;
     this.wrong = 0;
+    this.lives = lives;
     this.updateDisplay();
   }
 
@@ -64,7 +71,7 @@ export class StatsBoard {
     ctx.font = 'bold 48px system-ui, Arial, sans-serif';
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
-    const text = `Richtig: ${this.correct} | Falsch: ${this.wrong}`;
+    const text = `Richtig: ${this.correct} | Falsch: ${this.wrong} | Leben: ${this.lives}`;
 
     ctx.fillStyle = 'rgba(0, 0, 0, 0.5)';
     ctx.fillText(text, w / 2 + 2, h / 2 + 2);

--- a/src/xr-session.js
+++ b/src/xr-session.js
@@ -45,6 +45,7 @@ export class XRApp {
 
     // Statistik
     this.wrongCount = 0;
+    this.maxLives = 3;
 
     // Spieleinstellungen
     this.gameOperation = 'addition';
@@ -76,10 +77,14 @@ export class XRApp {
     this.grooveCharacter = new GrooveCharacterManager(this.sceneRig.scene);
     this.audio  = new AudioManager();
     this.ui.setAudioManager?.(this.audio);
-    
+
+    // Statistik zurücksetzen
+    this.wrongCount = 0;
+    this.grooveCharacter?.statsBoard?.reset?.(this.maxLives);
+
     // Spieleinstellungen an MathGame weitergeben
     this.math.setGameSettings(this.gameOperation, this.gameMaxResult);
-    
+
     // AudioManager an GrooveCharacter weitergeben
     this.grooveCharacter.setAudioManager(this.audio);
 
@@ -134,6 +139,12 @@ export class XRApp {
       // Callback auch bei manuellem Beenden aufrufen
       if (this.onSessionEnd) this.onSessionEnd();
     }
+  }
+
+  onGameOver() {
+    try { this.renderer?.setAnimationLoop(null); } catch {}
+    try { this.ui.setHudVisible?.(false); } catch {}
+    this.end();
   }
 
   cleanup() {
@@ -264,8 +275,13 @@ export class XRApp {
           this.wrongCount++;
           this.grooveCharacter?.playIncorrectAnimation();
           this.grooveCharacter?.statsBoard?.incrementWrong();
+          this.grooveCharacter?.statsBoard?.decrementLives();
           // Bump-Sound abspielen
           this.audio?.playBumpSound();
+
+          if (this.wrongCount >= this.maxLives) {
+            this.onGameOver();
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
- track remaining lives on StatsBoard and expose reset/decrement helpers
- reset stats before starting AR sessions and implement onGameOver
- stop AR loop on too many wrong answers and end session

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a853ad3e40832e8c8a597c26034146