### PR TITLE
Guard lives deduction by game mode

### DIFF
--- a/src/xr-session.js
+++ b/src/xr-session.js
@@ -280,14 +280,16 @@ export class XRApp {
         } else {
           // Falsche Antwort → Zähler erhöhen, StatsBoard & Sound aktualisieren
           this.wrongCount++;
-          this.lives--;
-          this.ui.setLives?.(this.lives);
-          this.grooveCharacter?.statsBoard?.setLives?.(this.lives);
+          if (this.gameMode === 'lives') {
+            this.lives--;
+            this.ui.setLives?.(this.lives);
+            this.grooveCharacter?.statsBoard?.setLives?.(this.lives);
+            if (this.lives <= 0) this.end();
+          }
           this.grooveCharacter?.playIncorrectAnimation();
           this.grooveCharacter?.statsBoard?.incrementWrong();
           // Bump-Sound abspielen
           this.audio?.playBumpSound();
-          if (this.lives <= 0) this.end();
         }
       }
     }


### PR DESCRIPTION
## Summary
- Only deduct lives and handle end logic when game mode is set to `lives`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a855a83d74832eb511a76d9c6e23a7