### PR TITLE
Add game mode handling

### DIFF
--- a/src/math-game.js
+++ b/src/math-game.js
@@ -20,6 +20,7 @@ export class MathGame {
     // Spieleinstellungen (Standard-Werte)
     this.operation = 'addition';
     this.maxResult = 20;
+    this.gameMode = 'endless';
   }
 
   attachBlocks(blocks, viewerPos = null, viewerQuat = null) {
@@ -54,6 +55,9 @@ export class MathGame {
       if (this.failManager && hitPosition) {
         this.failManager.spawn(hitPosition, new THREE.Vector3(0, 1, 0));
       }
+      if (this.gameMode === 'endless') {
+        this._newProblem(false);
+      }
     }
     return isCorrect;
   }
@@ -65,6 +69,10 @@ export class MathGame {
   setGameSettings(operation, maxResult) {
     this.operation = operation;
     this.maxResult = maxResult;
+  }
+
+  setGameMode(mode) {
+    this.gameMode = mode;
   }
 
   dispose() {

--- a/src/xr-session.js
+++ b/src/xr-session.js
@@ -60,6 +60,7 @@ export class XRApp {
 
   setGameMode(mode) {
     this.gameMode = mode;
+    this.math?.setGameMode(mode);
   }
 
   async startAR() {
@@ -90,6 +91,7 @@ export class XRApp {
     
     // Spieleinstellungen an MathGame weitergeben
     this.math.setGameSettings(this.gameOperation, this.gameMaxResult);
+    this.math.setGameMode(this.gameMode);
     
     // AudioManager an GrooveCharacter weitergeben
     this.grooveCharacter.setAudioManager(this.audio);


### PR DESCRIPTION
## Summary
- Support game modes in MathGame with a new setter and default endless mode
- Forward game mode from XRApp to MathGame and adjust problem flow for endless mode

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a855ab1d2c832e958680b4334229c7