### PR TITLE
feat: show game over delay before returning

### DIFF
--- a/src/equation-display.js
+++ b/src/equation-display.js
@@ -7,6 +7,7 @@ export class EquationDisplay {
     this.mesh = null;
     this.texCache = new Map();
     this._currentText = '';
+    this._currentColor = '#ffffff';
   }
 
   createDisplay(viewerPos, viewerQuat) {
@@ -38,15 +39,16 @@ export class EquationDisplay {
     
     // Erste Gleichung anzeigen falls vorhanden
     if (this._currentText) {
-      this.updateEquation(this._currentText);
+      this.updateEquation(this._currentText, this._currentColor);
     }
   }
 
-  updateEquation(text) {
+  updateEquation(text, color = '#ffffff') {
     this._currentText = text;
+    this._currentColor = color;
     if (!this.mesh) return;
 
-    const texture = this._getOrMakeEquationTexture(text);
+    const texture = this._getOrMakeEquationTexture(text, color);
     this.mesh.material.map = texture;
     this.mesh.material.needsUpdate = true;
   }
@@ -76,8 +78,9 @@ export class EquationDisplay {
     this.texCache.clear();
   }
 
-  _getOrMakeEquationTexture(text) {
-    if (this.texCache.has(text)) return this.texCache.get(text);
+  _getOrMakeEquationTexture(text, color) {
+    const key = `${color}|${text}`;
+    if (this.texCache.has(key)) return this.texCache.get(key);
 
     const canvas = document.createElement('canvas');
     canvas.width = 512;
@@ -102,15 +105,15 @@ export class EquationDisplay {
     ctx.fillStyle = 'rgba(0, 0, 0, 0.5)';
     ctx.fillText(text, canvas.width/2 + 2, canvas.height/2 + 2);
 
-    // Weißer Text
-    ctx.fillStyle = '#ffffff';
+    // Textfarbe
+    ctx.fillStyle = color;
     ctx.fillText(text, canvas.width/2, canvas.height/2);
 
     const texture = new THREE.CanvasTexture(canvas);
     texture.anisotropy = 4;
     texture.needsUpdate = true;
     
-    this.texCache.set(text, texture);
+    this.texCache.set(key, texture);
     return texture;
   }
 }

--- a/src/ui.js
+++ b/src/ui.js
@@ -44,8 +44,12 @@ export class UI {
   setLives(v) { if (this.livesEl) this.livesEl.textContent = `Lives: ${v}`; }
   setFps(fps) { if (this.fpsEl) this.fpsEl.textContent = `FPS: ${fps}`; }
 
-  setEquation(text) {
-    if (this.eqEl) { this.eqEl.textContent = text; this.eqEl.hidden = false; }
+  setEquation(text, color = '#ffffff') {
+    if (this.eqEl) {
+      this.eqEl.textContent = text;
+      this.eqEl.style.color = color;
+      this.eqEl.hidden = false;
+    }
   }
 
   toast(msg, ms = 2500) {

--- a/src/xr-session.js
+++ b/src/xr-session.js
@@ -46,6 +46,7 @@ export class XRApp {
     // Statistik
     this.wrongCount = 0;
     this.lives = 3;
+    this._gameOverShown = false;
 
     // Spieleinstellungen
     this.gameOperation = 'addition';
@@ -163,6 +164,14 @@ export class XRApp {
     }
   }
 
+  showGameOver() {
+    if (this._gameOverShown) return;
+    this._gameOverShown = true;
+    this.ui.setEquation?.('Game Over', '#ff0000');
+    this.math?.equationDisplay?.updateEquation('Game Over', '#ff0000');
+    setTimeout(() => this.end(), 4000);
+  }
+
   cleanup() {
     if (this.gameMode === 'lives') {
       this.ui.setLives?.(0);
@@ -210,6 +219,7 @@ export class XRApp {
     this._didWarmup = false;
     this.wrongCount = 0;
     this.lives = 3;
+    this._gameOverShown = false;
   }
 
   async _warmupPipelinesOnce() {
@@ -237,6 +247,11 @@ export class XRApp {
     this._prevTime = now;
 
     this._lastFrame = frame;
+
+    if (this._gameOverShown) {
+      this.renderer.render(this.sceneRig.scene, this.sceneRig.camera);
+      return;
+    }
 
     // Einmalige Platzierung der Blöcke, wenn ViewerPose vorliegt
     if (!this._placedBlocks) {
@@ -301,7 +316,7 @@ export class XRApp {
             this.lives--;
             this.ui.setLives?.(this.lives);
             this.grooveCharacter?.statsBoard?.setLives?.(this.lives);
-            if (this.lives <= 0) this.end();
+            if (this.lives <= 0) this.showGameOver();
           }
           this.grooveCharacter?.playIncorrectAnimation();
           this.grooveCharacter?.statsBoard?.incrementWrong();


### PR DESCRIPTION
## Summary
- allow equation display and DOM overlay to color text
- delay session end with a red 'Game Over' message when lives run out

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8532d2880832e8ff51cf3d42017df