### PR TITLE
Add 60-second timed game mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,17 +57,19 @@
           <div class="dropdown-options" hidden>
             <div class="dropdown-option selected" data-value="endless">Endlos</div>
             <div class="dropdown-option" data-value="lives">Leben</div>
+            <div class="dropdown-option" data-value="timed">Zeit</div>
           </div>
         </div>
       </div>
     </div>
-    
+
     <button id="start-ar">Starte AR</button>
 
     <div id="hud" hidden>
       <div class="row">
         <span id="score">Score: 0</span>
         <span id="lives">Lives: 3</span>
+        <span id="timer">Zeit: 60</span>
         <span id="fps">FPS: –</span>
       </div>
       <div class="row">

--- a/src/math-game.js
+++ b/src/math-game.js
@@ -55,7 +55,7 @@ export class MathGame {
       if (this.failManager && hitPosition) {
         this.failManager.spawn(hitPosition, new THREE.Vector3(0, 1, 0));
       }
-      if (this.gameMode === 'endless') {
+      if (this.gameMode === 'endless' || this.gameMode === 'timed') {
         this._newProblem(false);
       }
     }

--- a/src/stats-board.js
+++ b/src/stats-board.js
@@ -5,7 +5,8 @@ export class StatsBoard {
   constructor() {
     this.correct = 0;
     this.wrong = 0;
-    this.lives = 3;
+    this.secondaryLabel = 'Leben';
+    this.secondaryValue = 3;
 
     // Canvas setup
     this.canvas = document.createElement('canvas');
@@ -43,14 +44,22 @@ export class StatsBoard {
   }
 
   setLives(value) {
-    this.lives = value;
+    this.secondaryLabel = 'Leben';
+    this.secondaryValue = value;
+    this.updateDisplay();
+  }
+
+  setTime(value) {
+    this.secondaryLabel = 'Zeit';
+    this.secondaryValue = value;
     this.updateDisplay();
   }
 
   reset() {
     this.correct = 0;
     this.wrong = 0;
-    this.lives = 3;
+    this.secondaryLabel = 'Leben';
+    this.secondaryValue = 3;
     this.updateDisplay();
   }
 
@@ -72,7 +81,7 @@ export class StatsBoard {
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
     const line1 = `Richtig: ${this.correct} | Falsch: ${this.wrong}`;
-    const line2 = `Leben: ${this.lives}`;
+    const line2 = `${this.secondaryLabel}: ${this.secondaryValue}`;
 
     ctx.fillStyle = 'rgba(0, 0, 0, 0.5)';
     ctx.fillText(line1, w / 2 + 2, h / 2 - 24 + 2);

--- a/src/ui.js
+++ b/src/ui.js
@@ -4,6 +4,7 @@ export class UI {
     this.hud = document.getElementById('hud');
     this.scoreEl = document.getElementById('score');
     this.livesEl = document.getElementById('lives');
+    this.timerEl = document.getElementById('timer');
     this.fpsEl = document.getElementById('fps');
     this._toastTimer = null;
 
@@ -42,6 +43,7 @@ export class UI {
 
   setScore(v) { if (this.scoreEl) this.scoreEl.textContent = `Score: ${v}`; }
   setLives(v) { if (this.livesEl) this.livesEl.textContent = `Lives: ${v}`; }
+  setTimer(v) { if (this.timerEl) this.timerEl.textContent = `Zeit: ${v}`; }
   setFps(fps) { if (this.fpsEl) this.fpsEl.textContent = `FPS: ${fps}`; }
 
   setEquation(text, color = '#ffffff') {

--- a/src/xr-session.js
+++ b/src/xr-session.js
@@ -46,6 +46,7 @@ export class XRApp {
     // Statistik
     this.wrongCount = 0;
     this.lives = 3;
+    this.timeLeft = 60;
     this._gameOverShown = false;
 
     // Spieleinstellungen
@@ -94,6 +95,16 @@ export class XRApp {
       this.ui.setLives?.('-');             // oder HUD-Element verstecken
       this.grooveCharacter?.statsBoard?.setLives?.('-');
     }
+
+    // Timer je nach Spielmodus setzen
+    if (this.gameMode === 'timed') {
+      this.timeLeft = 60;
+      this.ui.setTimer?.(this.timeLeft);
+      this.grooveCharacter?.statsBoard?.setTime?.(this.timeLeft);
+    } else {
+      this.ui.setTimer?.('-');
+      this.grooveCharacter?.statsBoard?.setTime?.('-');
+    }
     
     // Spieleinstellungen an MathGame weitergeben
     this.math.setGameSettings(this.gameOperation, this.gameMaxResult);
@@ -137,6 +148,13 @@ export class XRApp {
           this.ui.setLives?.('-');
           this.grooveCharacter?.statsBoard?.setLives?.('-');
         }
+        if (this.gameMode === 'timed') {
+          this.ui.setTimer?.(0);
+          this.grooveCharacter?.statsBoard?.setTime?.(0);
+        } else {
+          this.ui.setTimer?.('-');
+          this.grooveCharacter?.statsBoard?.setTime?.('-');
+        }
       } catch {}
       this.cleanup();
       // Callback aufrufen, damit UI sich zurücksetzen kann
@@ -167,6 +185,11 @@ export class XRApp {
   showGameOver() {
     if (this._gameOverShown) return;
     this._gameOverShown = true;
+    if (this.gameMode === 'timed') {
+      this.timeLeft = 0;
+      this.ui.setTimer?.(0);
+      this.grooveCharacter?.statsBoard?.setTime?.(0);
+    }
     this.ui.setEquation?.('Game Over', '#ff0000');
     this.math?.equationDisplay?.updateEquation('Game Over', '#ff0000');
     setTimeout(() => this.end(), 4000);
@@ -179,6 +202,13 @@ export class XRApp {
     } else {
       this.ui.setLives?.('-');
       this.grooveCharacter?.statsBoard?.setLives?.('-');
+    }
+    if (this.gameMode === 'timed') {
+      this.ui.setTimer?.(0);
+      this.grooveCharacter?.statsBoard?.setTime?.(0);
+    } else {
+      this.ui.setTimer?.('-');
+      this.grooveCharacter?.statsBoard?.setTime?.('-');
     }
     // Animations-Loop stoppen
     try { this.renderer?.setAnimationLoop(null); } catch {}
@@ -219,6 +249,7 @@ export class XRApp {
     this._didWarmup = false;
     this.wrongCount = 0;
     this.lives = 3;
+    this.timeLeft = 60;
     this._gameOverShown = false;
   }
 
@@ -251,6 +282,16 @@ export class XRApp {
     if (this._gameOverShown) {
       this.renderer.render(this.sceneRig.scene, this.sceneRig.camera);
       return;
+    }
+
+    if (this.gameMode === 'timed') {
+      this.timeLeft -= dtMs / 1000;
+      const remaining = Math.ceil(this.timeLeft);
+      this.ui.setTimer?.(Math.max(0, remaining));
+      this.grooveCharacter?.statsBoard?.setTime?.(Math.max(0, remaining));
+      if (this.timeLeft <= 0) {
+        this.showGameOver();
+      }
     }
 
     // Einmalige Platzierung der Blöcke, wenn ViewerPose vorliegt


### PR DESCRIPTION
## Summary
- Add "timed" option to mode selection and HUD timer display
- Track 60‑second countdown in XR session and stats board
- Allow timed mode to advance after wrong answers like endless play

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a87c67e580832ea9af0e22bc115cb2