### PR TITLE
Stop updates when timer ends in timed mode

### DIFF
--- a/src/xr-session.js
+++ b/src/xr-session.js
@@ -286,12 +286,15 @@ export class XRApp {
 
     if (this.gameMode === 'timed') {
       this.timeLeft -= dtMs / 1000;
+      console.log('timeLeft:', this.timeLeft.toFixed(2)); // Debugging
+      if (this.timeLeft <= 0) {
+        this.showGameOver();
+        this.renderer.render(this.sceneRig.scene, this.sceneRig.camera);
+        return; // stop further updates once time is up
+      }
       const remaining = Math.ceil(this.timeLeft);
       this.ui.setTimer?.(Math.max(0, remaining));
       this.grooveCharacter?.statsBoard?.setTime?.(Math.max(0, remaining));
-      if (this.timeLeft <= 0) {
-        this.showGameOver();
-      }
     }
 
     // Einmalige Platzierung der Blöcke, wenn ViewerPose vorliegt


### PR DESCRIPTION
## Summary
- Stop frame updates when timed game mode timer expires
- Optionally log remaining time each frame for debugging

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a88077f080832ebbff57c635f998ac