### PR TITLE
Add timer support to stats board

### DIFF
--- a/src/stats-board.js
+++ b/src/stats-board.js
@@ -5,8 +5,8 @@ export class StatsBoard {
   constructor() {
     this.correct = 0;
     this.wrong = 0;
-    this.secondaryLabel = 'Leben';
-    this.secondaryValue = 3;
+    this.lives = 3;
+    this.timerValue = 0;
 
     // Canvas setup
     this.canvas = document.createElement('canvas');
@@ -44,22 +44,20 @@ export class StatsBoard {
   }
 
   setLives(value) {
-    this.secondaryLabel = 'Leben';
-    this.secondaryValue = value;
+    this.lives = value;
     this.updateDisplay();
   }
 
-  setTime(value) {
-    this.secondaryLabel = 'Zeit';
-    this.secondaryValue = value;
+  setTimer(value) {
+    this.timerValue = value;
     this.updateDisplay();
   }
 
   reset() {
     this.correct = 0;
     this.wrong = 0;
-    this.secondaryLabel = 'Leben';
-    this.secondaryValue = 3;
+    this.lives = 3;
+    this.timerValue = 0;
     this.updateDisplay();
   }
 
@@ -81,15 +79,22 @@ export class StatsBoard {
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
     const line1 = `Richtig: ${this.correct} | Falsch: ${this.wrong}`;
-    const line2 = `${this.secondaryLabel}: ${this.secondaryValue}`;
+    const line2 = `Leben: ${this.lives}`;
+    const line3 = `Zeit: ${this.timerValue}`;
+
+    const y1 = h / 4;
+    const y2 = h / 2;
+    const y3 = (3 * h) / 4;
 
     ctx.fillStyle = 'rgba(0, 0, 0, 0.5)';
-    ctx.fillText(line1, w / 2 + 2, h / 2 - 24 + 2);
-    ctx.fillText(line2, w / 2 + 2, h / 2 + 24 + 2);
+    ctx.fillText(line1, w / 2 + 2, y1 + 2);
+    ctx.fillText(line2, w / 2 + 2, y2 + 2);
+    ctx.fillText(line3, w / 2 + 2, y3 + 2);
 
     ctx.fillStyle = '#ffffff';
-    ctx.fillText(line1, w / 2, h / 2 - 24);
-    ctx.fillText(line2, w / 2, h / 2 + 24);
+    ctx.fillText(line1, w / 2, y1);
+    ctx.fillText(line2, w / 2, y2);
+    ctx.fillText(line3, w / 2, y3);
 
     this.texture.needsUpdate = true;
   }

--- a/src/xr-session.js
+++ b/src/xr-session.js
@@ -100,10 +100,10 @@ export class XRApp {
     if (this.gameMode === 'timed') {
       this.timeLeft = 60;
       this.ui.setTimer?.(this.timeLeft);
-      this.grooveCharacter?.statsBoard?.setTime?.(this.timeLeft);
+      this.grooveCharacter?.statsBoard?.setTimer?.(this.timeLeft);
     } else {
       this.ui.setTimer?.('-');
-      this.grooveCharacter?.statsBoard?.setTime?.('-');
+      this.grooveCharacter?.statsBoard?.setTimer?.('-');
     }
     
     // Spieleinstellungen an MathGame weitergeben
@@ -150,10 +150,10 @@ export class XRApp {
         }
         if (this.gameMode === 'timed') {
           this.ui.setTimer?.(0);
-          this.grooveCharacter?.statsBoard?.setTime?.(0);
+          this.grooveCharacter?.statsBoard?.setTimer?.(0);
         } else {
           this.ui.setTimer?.('-');
-          this.grooveCharacter?.statsBoard?.setTime?.('-');
+          this.grooveCharacter?.statsBoard?.setTimer?.('-');
         }
       } catch {}
       this.cleanup();
@@ -188,7 +188,7 @@ export class XRApp {
     if (this.gameMode === 'timed') {
       this.timeLeft = 0;
       this.ui.setTimer?.(0);
-      this.grooveCharacter?.statsBoard?.setTime?.(0);
+      this.grooveCharacter?.statsBoard?.setTimer?.(0);
     }
     this.ui.setEquation?.('Game Over', '#ff0000');
     this.math?.equationDisplay?.updateEquation('Game Over', '#ff0000');
@@ -205,10 +205,10 @@ export class XRApp {
     }
     if (this.gameMode === 'timed') {
       this.ui.setTimer?.(0);
-      this.grooveCharacter?.statsBoard?.setTime?.(0);
+      this.grooveCharacter?.statsBoard?.setTimer?.(0);
     } else {
       this.ui.setTimer?.('-');
-      this.grooveCharacter?.statsBoard?.setTime?.('-');
+      this.grooveCharacter?.statsBoard?.setTimer?.('-');
     }
     // Animations-Loop stoppen
     try { this.renderer?.setAnimationLoop(null); } catch {}
@@ -288,7 +288,7 @@ export class XRApp {
       this.timeLeft -= dtMs / 1000;
       const remaining = Math.ceil(this.timeLeft);
       this.ui.setTimer?.(Math.max(0, remaining));
-      this.grooveCharacter?.statsBoard?.setTime?.(Math.max(0, remaining));
+      this.grooveCharacter?.statsBoard?.setTimer?.(Math.max(0, remaining));
       if (this.timeLeft <= 0) {
         this.showGameOver();
       }


### PR DESCRIPTION
## Summary
- Track lives and countdown separately in StatsBoard with new timer API
- Display three lines on the board: "Richtig | Falsch", "Leben", and "Zeit"
- Initialize and update timer during timed game mode

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8807a5c1c832e85a7c9b95535a02c