### PR TITLE
Show solved count on timed Game Over

### DIFF
--- a/src/xr-session.js
+++ b/src/xr-session.js
@@ -185,14 +185,18 @@ export class XRApp {
   showGameOver() {
     if (this._gameOverShown) return;
     this._gameOverShown = true;
+
+    let msg = 'Game Over';
+
     if (this.gameMode === 'timed') {
       this.timeLeft = 0;
       this.ui.setTimer?.(0);
       this.grooveCharacter?.statsBoard?.setTime?.(0);
+
+      // Anzahl richtig gelöster Aufgaben ermitteln
+      const solved = this.grooveCharacter?.statsBoard?.correct ?? 0;
+      msg += `\nGelöste Aufgaben: ${solved}`;
     }
-    // Anzahl richtig gelöster Aufgaben ermitteln
-    const solved = this.grooveCharacter?.statsBoard?.correct ?? 0;
-    const msg = `Game Over\nGelöste Aufgaben: ${solved}`;
 
     // HUD & 3D-Equation entsprechend erweitern
     this.ui.setEquation?.(msg, '#ff0000');


### PR DESCRIPTION
## Summary
- Display number of correctly solved tasks when the timer ends and reflect it in HUD and 3D equation banner

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a882ff8d28832eb7a0657fb665cc89